### PR TITLE
Improvements to the user provider

### DIFF
--- a/src/UserProvider.php
+++ b/src/UserProvider.php
@@ -14,10 +14,12 @@ use UserBase\Client\Model\User;
 class UserProvider implements UserProviderInterface
 {
     private $client;
+    private $shouldRefresh;
 
-    public function __construct(Client $client)
+    public function __construct(Client $client, $shouldRefresh = true)
     {
         $this->client = $client;
+        $this->shouldRefresh = (bool) $shouldRefresh;
     }
 
     public function loadUserByUsername($username)
@@ -37,6 +39,10 @@ class UserProvider implements UserProviderInterface
     {
         if (!$user instanceof User) {
             throw new UnsupportedUserException(sprintf('Instances of "%s" are not supported.', get_class($user)));
+        }
+
+        if (!$this->shouldRefresh) {
+            return $user;
         }
 
         return $this->loadUserByUsername($user->getUsername());

--- a/src/UserProvider.php
+++ b/src/UserProvider.php
@@ -44,6 +44,6 @@ final class UserProvider implements UserProviderInterface
 
     public function supportsClass($class)
     {
-        return $class === 'Symfony\Component\Security\Core\User\User';
+        return $class === User::class;
     }
 }

--- a/src/UserProvider.php
+++ b/src/UserProvider.php
@@ -11,7 +11,7 @@ use Symfony\Component\Security\Core\User\UserProviderInterface;
 
 use UserBase\Client\Model\User;
 
-final class UserProvider implements UserProviderInterface
+class UserProvider implements UserProviderInterface
 {
     private $client;
 

--- a/src/UserProvider.php
+++ b/src/UserProvider.php
@@ -2,13 +2,12 @@
 
 namespace UserBase\Client;
 
-use Symfony\Component\Security\Core\User\UserProviderInterface;
-use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
 use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Core\User\UserProviderInterface;
+
 use UserBase\Client\Model\User;
-use UserBase\Client\Client;
-use RuntimeException;
 
 final class UserProvider implements UserProviderInterface
 {
@@ -28,7 +27,6 @@ final class UserProvider implements UserProviderInterface
         return $user;
     }
 
-    // Needed for symfony user provider interface
     public function refreshUser(UserInterface $user)
     {
         if (!$user instanceof User) {
@@ -37,8 +35,6 @@ final class UserProvider implements UserProviderInterface
 
         return $this->loadUserByUsername($user->getUsername());
     }
-
-    // Needed for symfony user provider interface
 
     public function supportsClass($class)
     {

--- a/src/UserProvider.php
+++ b/src/UserProvider.php
@@ -2,6 +2,8 @@
 
 namespace UserBase\Client;
 
+use RuntimeException;
+
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
 use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
 use Symfony\Component\Security\Core\User\UserInterface;
@@ -20,11 +22,15 @@ final class UserProvider implements UserProviderInterface
 
     public function loadUserByUsername($username)
     {
-        $user = $this->client->getUserByUsername($username);
-        if (!$user) {
-            throw new UsernameNotFoundException(sprintf('User %s is not found.', $username));
+        try {
+            return $this->client->getUserByUsername($username);
+        } catch (RuntimeException $e) {
+            throw new UsernameNotFoundException(
+                "A User named \"{$username}\" cannot be found in Userbase.",
+                null,
+                $e
+            );
         }
-        return $user;
     }
 
     public function refreshUser(UserInterface $user)


### PR DESCRIPTION
A major version number bump is required because of 6118752 - the commit catches exceptions thrown by the client instead of allowing them to bubble up to the caller. This makes the provider compatible with UserProviderInterface.

The other possibly breaking change is 62e4ab8, which makes the provider report that it supports its own User class (previously it reported that it supports the Symfony User class which was not quite true).  This is unlikely to have any effect on apps depending on the provider.

The main reason for this PR is to allow the configuration of the behaviour of the user provider when the app retrieves the User from the session (b4a5484). Previously, the provider would always ask the userbase client to fetch the (possibly locally cached) user info.  Now it is possible to forego the round trip to (the cache or to) userbase and just use the user info stored in the session. The original behaviour is the default.