### PR TITLE
Let apps supply roles for users

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
     ],
     "require": {
         "php": ">=5.3.0",
+        "linkorb/userbase-role-contracts": "^1.0",
         "symfony/security": "~2.6 || ~3.0 || ^4",
         "psr/cache": "~1.0",
         "symfony/cache": "~3.0 || ^4"

--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -2,11 +2,16 @@
 
 namespace UserBase\Client\Model;
 
+use LinkORB\Contracts\UserbaseRole\RoleInterface;
 use Symfony\Component\Security\Core\User\AdvancedUserInterface;
-use Symfony\Component\Security\Core\Role\Role;
 use RuntimeException;
 
-final class User implements UserInterface, AdvancedUserInterface, AccountContainerInterface, PolicyContainerInterface
+final class User implements
+    AccountContainerInterface,
+    AdvancedUserInterface,
+    PolicyContainerInterface,
+    RoleInterface,
+    UserInterface
 {
     private $password;
     private $enabled;

--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -14,11 +14,11 @@ final class User implements UserInterface, AdvancedUserInterface, AccountContain
     private $credentialsNonExpired;
     private $accountNonLocked;
     private $roles;
-    
+
     private $createdAt;
     private $lastSeenAt;
     private $deletedAt;
-    
+
     private $accountUsers = array();
     private $policies = array();
 
@@ -37,34 +37,34 @@ final class User implements UserInterface, AdvancedUserInterface, AccountContain
         $this->roles = array();
         $this->salt = "KJH6212kjwek_fj23D01-239.1023fkjdsj^k2hdfssfjk!h234uiy4324";
     }
-    
+
     public function getCreatedAt()
     {
         return $this->createdAt;
     }
-    
+
     public function setCreatedAt($createdAt)
     {
         $this->createdAt = $createdAt;
         return $this;
     }
-    
+
     public function getDeletedAt()
     {
         return $this->deletedAt;
     }
-    
+
     public function setDeletedAt($deletedAt)
     {
         $this->deletedAt = $deletedAt;
         return $this;
     }
-        
+
     public function getLastSeenAt()
     {
         return $this->lastSeenAt;
     }
-    
+
     public function setLastSeenAt($lastSeenAt)
     {
         if ($this->lastSeenAt>0) {
@@ -72,7 +72,7 @@ final class User implements UserInterface, AdvancedUserInterface, AccountContain
         }
         return $this;
     }
-    
+
     /**
      * {@inheritdoc}
      */
@@ -88,7 +88,7 @@ final class User implements UserInterface, AdvancedUserInterface, AccountContain
     {
         return $this->password;
     }
-    
+
     public function setPassword($password)
     {
         $this->password = $password;
@@ -115,18 +115,18 @@ final class User implements UserInterface, AdvancedUserInterface, AccountContain
         $this->name = $username;
         return $this;
     }
-    
+
     public function getName()
     {
         return $this->name;
     }
-    
+
     public function getDisplayName()
     {
         $account = $this->getUserAccount();
         return $account->getDisplayName();
     }
-    
+
     /**
      * {@inheritdoc}
      */
@@ -165,7 +165,7 @@ final class User implements UserInterface, AdvancedUserInterface, AccountContain
     {
         return $this->enabled;
     }
-    
+
     public function setEnabled($enabled)
     {
         $this->enabled = $enabled;
@@ -178,12 +178,12 @@ final class User implements UserInterface, AdvancedUserInterface, AccountContain
     public function eraseCredentials()
     {
     }
-    
+
     public function getEmail()
     {
         return $this->getUserAccount()->getEmail();
     }
-    
+
     public function getPictureUrl($size = null)
     {
         return $this->getUserAccount()->getPictureUrl($size);
@@ -193,12 +193,12 @@ final class User implements UserInterface, AdvancedUserInterface, AccountContain
     {
         $this->accountUsers[] = $accountUser;
     }
-    
+
     public function getAccountUsers()
     {
         return $this->accountUsers;
     }
-    
+
     public function getAccounts()
     {
         $accounts = array();
@@ -207,7 +207,7 @@ final class User implements UserInterface, AdvancedUserInterface, AccountContain
         }
         return $accounts;
     }
-    
+
     public function getUserAccount()
     {
         foreach ($this->getAccounts() as $account) {
@@ -217,7 +217,7 @@ final class User implements UserInterface, AdvancedUserInterface, AccountContain
         }
         throw new RuntimeException("This user has no user-account: " . $this->getName());
     }
-    
+
     public function getAccountsByType($type)
     {
         $res = array();
@@ -228,17 +228,17 @@ final class User implements UserInterface, AdvancedUserInterface, AccountContain
         }
         return $res;
     }
-    
+
     public function addPolicy(Policy $policy)
     {
         $this->policies[] = $policy;
     }
-    
+
     public function getPolicies()
     {
         return $this->policies;
     }
-    
+
     public function addRole($roleName)
     {
         $this->roles[] = $roleName;


### PR DESCRIPTION
## Proposed changes

With this change UserProvider will, when furnished with an implementation of RoleProviderInterface, ask for role information for the User it is has loaded and apply those roles to the User.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Further Information

This feature is made real by the new [userbase-role-provder-bundle](https://github.com/linkorb/userbase-role-provider-bundle) which injects an instance of [FixedRolesRoleProvider](https://github.com/linkorb/userbase-role-provider-bundle/blob/master/RoleProvider/FixedRolesRoleProvider.php) into UserProvider (as configured by userbase-client-bundle).  The roles are [loaded from a map of username to roles in a yaml file](https://github.com/linkorb/userbase-role-provider-bundle/blob/master/RoleLoader/YamlRoleLoader.php).

For [card #2595](https://team.linkorb.com/cards/2595).