### PR TITLE
Compatible with Symfony 5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+/.php_cs
+/.php_cs.cache
 vendor/*
 .env
 composer.lock

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,0 +1,25 @@
+<?php
+
+$finder = PhpCsFixer\Finder::create()
+    ->in(__DIR__.'/src')
+;
+
+return PhpCsFixer\Config::create()
+    ->setRules([
+        '@PSR1' => true,
+        '@PSR2' => true,
+        '@Symfony' => true,
+        'single_line_throw' => false,
+        'no_superfluous_phpdoc_tags' => false,
+        'ordered_imports' => true,
+        'phpdoc_align' => false,
+        'no_extra_consecutive_blank_lines' => false,
+        'blank_line_before_statement' => [
+            'statements' => [
+                'declare',
+            ]
+        ],
+        'array_syntax' => false,
+    ])
+    ->setFinder($finder)
+;

--- a/README.md
+++ b/README.md
@@ -52,9 +52,10 @@ Please refer to the `examples/` directory for other examples.
 
 A Silex Provider is available [here](https://github.com/linkorb/silex-provider-userbase-client)
 
-### Symfony 4
+### Symfony
 
-A Symfony 4 bundle can be found [here](https://github.com/linkorb/userbase-client-bundle)
+A Symfony bundle can be found [here](https://github.com/linkorb/userbase-client-bundle).
+It works with Symfony 4 and 5 projects.
 
 ## License
 

--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -1,0 +1,10 @@
+UPGRADE FROM 1.9 to 2.0
+=======================
+
+- The User class no longer implements Symfony's `AdvancedUserInterface` which
+  it has been removed from Symfony 5.  Use of the methods of this interface
+  should be replaced by performing User and Account checks in UserCheckers.
+
+  A temporary replacement for the removed interface is
+  `UserBase\Client\Model\LegacyAdvancedUserInterface`, but use this only as a
+  last resort and as a temporary fix.

--- a/composer.json
+++ b/composer.json
@@ -18,14 +18,14 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "linkorb/userbase-role-contracts": "^1.0",
-        "symfony/security": "~2.6 || ~3.0 || ^4.0|| ^5.0",
+        "linkorb/envoi": "^1.1",
+        "linkorb/userbase-role-contracts": "^2.0",
         "psr/cache": "~1.0",
-        "symfony/cache": "~3.0|| ^4.0 || ^5.0 ",
-        "linkorb/envoi": "^1.1"
+        "symfony/cache": "~3.0 || ^4.0 || ^5.0",
+        "symfony/security-core": "~2.6 || ~3.0 || ^4.0 || ^5.0"
     },
     "require-dev": {
-      "symfony/dotenv": "~3.0 || ^4.0"
+      "symfony/dotenv": "~3.0 || ^4.0 || ^5.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Client.php
+++ b/src/Client.php
@@ -2,14 +2,16 @@
 
 namespace UserBase\Client;
 
-use UserBase\Client\Model\User;
-use UserBase\Client\Model\Account;
-use UserBase\Client\Model\AccountUser;
-use UserBase\Client\Model\AccountEmail;
-use UserBase\Client\Model\AccountProperty;
-use UserBase\Client\Model\Policy;
 use Psr\Cache\CacheItemPoolInterface;
 use RuntimeException;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Security\Core\Encoder\MessageDigestPasswordEncoder;
+use UserBase\Client\Model\Account;
+use UserBase\Client\Model\AccountEmail;
+use UserBase\Client\Model\AccountProperty;
+use UserBase\Client\Model\AccountUser;
+use UserBase\Client\Model\Policy;
+use UserBase\Client\Model\User;
 
 if (!function_exists('curl_file_create')) {
     function curl_file_create($filename, $mimetype = '', $postname = '')
@@ -52,7 +54,7 @@ class Client
         }
 
         $this->partition = $partition;
-        $this->cache = new \Symfony\Component\Cache\Adapter\ArrayAdapter();
+        $this->cache = new ArrayAdapter();
     }
 
     private function parse_dsn(array $parts)
@@ -285,8 +287,7 @@ class Client
 
         $json = curl_exec($ch);
 
-        if($json === false)
-        {
+        if (false === $json) {
             throw new RuntimeException('Curl error: '.curl_error($ch));
         }
 
@@ -295,7 +296,6 @@ class Client
         if ($this->timeDataCollector) {
             $this->timeDataCollector->stopMeasure('getData');
         }
-
 
         if (200 != $code) {
             throw new RuntimeException('HTTP Status code: '.$code.'message: '.$json);
@@ -313,7 +313,7 @@ class Client
         } catch (\Exception $e) {
             return false;
         }
-        $encoder = new \Symfony\Component\Security\Core\Encoder\MessageDigestPasswordEncoder();
+        $encoder = new MessageDigestPasswordEncoder();
         $valid = $encoder->isPasswordValid($user->getPassword(), $password, $user->getSalt());
 
         return $valid;

--- a/src/Model/Account.php
+++ b/src/Model/Account.php
@@ -15,225 +15,239 @@ class Account
     private $mobile;
     private $mobile_verified;
     private $status;
-    
+
     private $createdAt;
     private $deletedAt;
     private $accountType;
     private $url;
-    
+
     public function __construct($name)
     {
         $this->name = $name;
     }
-    
+
     public function getName()
     {
         return $this->name;
     }
-    
+
     public function setName($name)
     {
         $this->name = $name;
+
         return $this;
     }
-    
+
     public function getDisplayName()
     {
         if ($this->displayName) {
             return $this->displayName;
         }
+
         return $this->name;
     }
-    
+
     public function setDisplayName($displayName)
     {
         $this->displayName = $displayName;
+
         return $this;
     }
-    
+
     public function getAbout()
     {
         return $this->about;
     }
-    
+
     public function setAbout($about)
     {
         $this->about = $about;
+
         return $this;
     }
-    
-    
+
     public function getPictureUrl()
     {
         return $this->pictureUrl;
     }
-    
+
     public function setPictureUrl($pictureUrl)
     {
         $this->pictureUrl = $pictureUrl;
+
         return $this;
     }
-    
+
     public function getEmail()
     {
         return $this->email;
     }
-    
+
     public function setEmail($email)
     {
         $this->email = $email;
+
         return $this;
     }
-    
+
     public function getEmailVerified()
     {
         return $this->email_verified;
     }
-    
+
     public function setEmailVerified($email_verified)
     {
         $this->email_verified = $email_verified;
+
         return $this;
     }
-    
-    
+
     public function getMobile()
     {
         return $this->mobile;
     }
-    
+
     public function setMobile($mobile)
     {
         $this->mobile = $mobile;
+
         return $this;
     }
-    
+
     public function getMobileVerified()
     {
         return $this->mobile_verified;
     }
-    
+
     public function setMobileVerified($mobile_verified)
     {
         $this->mobile_verified = $mobile_verified;
+
         return $this;
     }
-    
-    
+
     public function getStatus()
     {
         return $this->status;
     }
-    
+
     public function setStatus($status)
     {
         $this->status = $status;
+
         return $this;
     }
-    
+
     public function getCreatedAt()
     {
         return $this->createdAt;
     }
-    
+
     public function setCreatedAt($createdAt)
     {
         $this->createdAt = $createdAt;
+
         return $this;
     }
-    
+
     public function getDeletedAt()
     {
         return $this->deletedAt;
     }
-    
+
     public function setDeletedAt($deletedAt)
     {
         $this->deletedAt = $deletedAt;
+
         return $this;
     }
-    
+
     public function getAccountType()
     {
         return $this->accountType;
     }
-    
+
     public function setAccountType($accountType)
     {
         $this->accountType = $accountType;
+
         return $this;
     }
-    
+
     private $accountUsers = array();
-    
+
     public function addAccountUser(AccountUser $accountUser)
     {
         $this->accountUsers[] = $accountUser;
+
         return $this;
     }
-    
+
     public function getAccountUsers()
     {
         return $this->accountUsers;
     }
-    
+
     public function isAccountUser($userName)
     {
         foreach ($this->accountUser as $accountUser) {
-            if ($this->accountUser->getUserName()==$userName) {
+            if ($this->accountUser->getUserName() == $userName) {
                 return true;
             }
         }
+
         return false;
     }
 
-
     private $accountEmails = array();
-    
+
     public function addAccountEmail(AccountEmail $accountEmail)
     {
         $this->accountEmails[] = $accountEmail;
+
         return $this;
     }
-    
+
     public function getAccountEmails()
     {
         return $this->accountEmails;
     }
-    
+
     public function hasVerifiedEmailDomain($emailDomain)
     {
-        if ($emailDomain[0]!='@') {
+        if ('@' != $emailDomain[0]) {
             throw new InvalidArgumentException('Make sure the domain argument starts with @');
         }
         foreach ($this->accountEmails as $accountEmail) {
-            if ($accountEmail->getVerifiedAt()>0) {
-                if (substr($accountEmail->getEmail(), -strlen($emailDomain))==$emailDomain) {
+            if ($accountEmail->getVerifiedAt() > 0) {
+                if (substr($accountEmail->getEmail(), -strlen($emailDomain)) == $emailDomain) {
                     return true;
                 }
             }
         }
+
         return false;
     }
-    
+
     private $accountProperties = array();
-    
+
     public function addAccountProperty(AccountProperty $accountProperty)
     {
         $this->accountProperties[$accountProperty->getName()] = $accountProperty;
+
         return $this;
     }
-    
+
     public function getAccountProperties()
     {
         return $this->accountProperties;
     }
-    
+
     public function getAccountProperty($name)
     {
         return $this->accountProperties[$name];
     }
-    
+
     public function hasAccountProperty($name)
     {
         return isset($this->accountProperties[$name]);
@@ -241,38 +255,40 @@ class Account
 
     private $message;
     private $expireAt;
-    
-    
+
     public function getMessage()
     {
         return $this->message;
     }
-    
+
     public function setMessage($message)
     {
         $this->message = $message;
+
         return $this;
     }
-    
+
     public function getExpireAt()
     {
         return $this->expireAt;
     }
-    
+
     public function setExpireAt($expireAt)
     {
         $this->expireAt = $expireAt;
+
         return $this;
     }
-    
+
     public function getUrl()
     {
         return $this->url;
     }
-    
+
     public function setUrl($url)
     {
         $this->url = $url;
+
         return $this;
     }
 }

--- a/src/Model/AccountContainerInterface.php
+++ b/src/Model/AccountContainerInterface.php
@@ -4,5 +4,4 @@ namespace UserBase\Client\Model;
 
 interface AccountContainerInterface
 {
-    
 }

--- a/src/Model/AccountEmail.php
+++ b/src/Model/AccountEmail.php
@@ -8,50 +8,52 @@ class AccountEmail
     private $email;
     private $verified_at;
     private $primary;
-    
+
     public function getAccountName()
     {
         return $this->accountName;
     }
-    
+
     public function setAccountName($accountName)
     {
         $this->accountName = $accountName;
+
         return $this;
     }
-    
+
     public function getEmail()
     {
         return $this->email;
     }
-    
+
     public function setEmail($email)
     {
         $this->email = $email;
+
         return $this;
     }
-    
+
     public function getVerifiedAt()
     {
         return $this->verified_at;
     }
-    
+
     public function setVerifiedAt($verified_at)
     {
         $this->verified_at = $verified_at;
+
         return $this;
     }
-    
+
     public function isPrimary()
     {
         return $this->primary;
     }
-    
+
     public function setPrimary($primary)
     {
         $this->primary = $primary;
+
         return $this;
     }
-    
-    
 }

--- a/src/Model/AccountProperty.php
+++ b/src/Model/AccountProperty.php
@@ -7,40 +7,40 @@ class AccountProperty
     private $accountName;
     private $name;
     private $value;
-    
+
     public function getAccountName()
     {
         return $this->accountName;
     }
-    
+
     public function setAccountName($accountName)
     {
         $this->accountName = $accountName;
+
         return $this;
     }
-    
+
     public function getName()
     {
         return $this->name;
     }
-    
+
     public function setName($name)
     {
         $this->name = $name;
+
         return $this;
     }
-    
+
     public function getValue()
     {
         return $this->value;
     }
-    
+
     public function setValue($value)
     {
         $this->value = $value;
+
         return $this;
     }
-    
-    
-    
 }

--- a/src/Model/AccountUser.php
+++ b/src/Model/AccountUser.php
@@ -7,34 +7,36 @@ class AccountUser
     private $accountName;
     private $userName;
     private $isOwner = false;
-    
+
     public function getAccountName()
     {
         return $this->accountName;
     }
-    
+
     public function setAccountName($accountName)
     {
         $this->accountName = $accountName;
+
         return $this;
     }
-    
+
     public function getUserName()
     {
         return $this->userName;
     }
-    
+
     public function setUserName($userName)
     {
         $this->userName = $userName;
+
         return $this;
     }
-    
+
     public function isOwner()
     {
-        return ($this->isOwner==true);
+        return true == $this->isOwner;
     }
-    
+
     public function setIsOwner($isOwner)
     {
         if ($isOwner) {
@@ -42,32 +44,35 @@ class AccountUser
         } else {
             $this->isOwner = false;
         }
+
         return $this;
     }
-    
+
     private $account;
-    
+
     public function getAccount()
     {
         return $this->account;
     }
-    
+
     public function setAccount(Account $account)
     {
         $this->account = $account;
+
         return $this;
     }
-    
+
     private $user;
-    
+
     public function getUser()
     {
         return $this->user;
     }
-    
+
     public function setUser($user)
     {
         $this->user = $user;
+
         return $this;
     }
 }

--- a/src/Model/LegacyAdvancedUserInterface.php
+++ b/src/Model/LegacyAdvancedUserInterface.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace UserBase\Client\Model;
+
+/**
+ * For backwards compatability only - use UserCheckers instead.
+ *
+ * This iface replaces Symfony\Component\Security\Core\User\AdvancedUserInterface
+ * which was removed from Symfony 5 because the User class is not the right place
+ * to implement account/user checks that influence whether or not a user is
+ * allowed to authenticate.  For more info about why it was removed see:
+ * https://github.com/symfony/symfony/issues/23292
+ *
+ * For info about UserCheckers see:
+ * https://symfony.com/doc/current/security/user_checkers.html
+ */
+interface LegacyAdvancedUserInterface extends UserInterface
+{
+    /**
+     * Check whether the user's account has expired.
+     *
+     * @return bool true if the user's account is non expired, false otherwise
+     */
+    public function isAccountNonExpired();
+
+    /**
+     * Check whether the user is locked.
+     *
+     * @return bool true if the user is not locked, false otherwise
+     */
+    public function isAccountNonLocked();
+
+    /**
+     * Check whether the user's credentials have expired.
+     *
+     * @return bool true if the user's credentials are non expired, false otherwise
+     */
+    public function isCredentialsNonExpired();
+
+    /**
+     * Check whether the user is enabled.
+     *
+     * @return bool true if the user is enabled, false otherwise
+     */
+    public function isEnabled();
+}

--- a/src/Model/Policy.php
+++ b/src/Model/Policy.php
@@ -7,34 +7,36 @@ class Policy
     private $effect;
     private $actions = array();
     private $resource;
-    
+
     public function getEffect()
     {
         return $this->effect;
     }
-    
+
     public function setEffect($effect)
     {
         $this->effect = $effect;
+
         return $this;
     }
-    
+
     public function getResource()
     {
         return $this->resource;
     }
-    
+
     public function setResource($resource)
     {
         $this->resource = $resource;
+
         return $this;
     }
-    
+
     public function addAction($action)
     {
         return $this->actions[$action] = true;
     }
-    
+
     public function getActions()
     {
         return $this->actions;

--- a/src/Model/PolicyContainerInterface.php
+++ b/src/Model/PolicyContainerInterface.php
@@ -4,5 +4,4 @@ namespace UserBase\Client\Model;
 
 interface PolicyContainerInterface
 {
-    
 }

--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -4,20 +4,34 @@ namespace UserBase\Client\Model;
 
 use LinkORB\Contracts\UserbaseRole\RoleInterface;
 use RuntimeException;
-use Symfony\Component\Security\Core\User\AdvancedUserInterface;
+use Symfony\Component\Security\Core\User\UserInterface as BaseUserInterface;
 
 final class User implements
     AccountContainerInterface,
-    AdvancedUserInterface,
+    BaseUserInterface,
+    LegacyAdvancedUserInterface,
     PolicyContainerInterface,
     RoleInterface,
     UserInterface
 {
-    private $password;
+    /**
+     * @deprecated
+     */
     private $enabled;
+    /**
+     * @deprecated
+     */
     private $accountNonExpired;
+    /**
+     * @deprecated
+     */
     private $credentialsNonExpired;
+    /**
+     * @deprecated
+     */
     private $accountNonLocked;
+
+    private $password;
     private $roles;
 
     private $createdAt;
@@ -134,7 +148,7 @@ final class User implements
     }
 
     /**
-     * {@inheritdoc}
+     * @deprecated
      */
     public function isAccountNonExpired()
     {
@@ -142,13 +156,16 @@ final class User implements
     }
 
     /**
-     * {@inheritdoc}
+     * @deprecated
      */
     public function isAccountNonLocked()
     {
         return $this->accountNonLocked;
     }
 
+    /**
+     * @deprecated
+     */
     public function setAccountNonLocked($accountNonLocked)
     {
         $this->accountNonLocked = $accountNonLocked;
@@ -157,7 +174,7 @@ final class User implements
     }
 
     /**
-     * {@inheritdoc}
+     * @deprecated
      */
     public function isCredentialsNonExpired()
     {
@@ -165,13 +182,16 @@ final class User implements
     }
 
     /**
-     * {@inheritdoc}
+     * @deprecated
      */
     public function isEnabled()
     {
         return $this->enabled;
     }
 
+    /**
+     * @deprecated
+     */
     public function setEnabled($enabled)
     {
         $this->enabled = $enabled;

--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -3,8 +3,8 @@
 namespace UserBase\Client\Model;
 
 use LinkORB\Contracts\UserbaseRole\RoleInterface;
-use Symfony\Component\Security\Core\User\AdvancedUserInterface;
 use RuntimeException;
+use Symfony\Component\Security\Core\User\AdvancedUserInterface;
 
 final class User implements
     AccountContainerInterface,
@@ -40,7 +40,7 @@ final class User implements
         $this->credentialsNonExpired = true;
         $this->accountNonLocked = true;
         $this->roles = array();
-        $this->salt = "KJH6212kjwek_fj23D01-239.1023fkjdsj^k2hdfssfjk!h234uiy4324";
+        $this->salt = 'KJH6212kjwek_fj23D01-239.1023fkjdsj^k2hdfssfjk!h234uiy4324';
     }
 
     public function getCreatedAt()
@@ -72,7 +72,7 @@ final class User implements
 
     public function setLastSeenAt($lastSeenAt)
     {
-        if ($this->lastSeenAt>0) {
+        if ($this->lastSeenAt > 0) {
             $this->lastSeenAt = $lastSeenAt;
         }
         return $this;
@@ -115,6 +115,7 @@ final class User implements
     {
         return $this->getName();
     }
+
     public function setUsername($username)
     {
         $this->name = $username;
@@ -220,7 +221,7 @@ final class User implements
                 return $account;
             }
         }
-        throw new RuntimeException("This user has no user-account: " . $this->getName());
+        throw new RuntimeException('This user has no user-account: '.$this->getName());
     }
 
     public function getAccountsByType($type)

--- a/src/Model/UserInterface.php
+++ b/src/Model/UserInterface.php
@@ -4,5 +4,4 @@ namespace UserBase\Client\Model;
 
 interface UserInterface
 {
-    
 }

--- a/src/UserProvider.php
+++ b/src/UserProvider.php
@@ -5,11 +5,11 @@ namespace UserBase\Client;
 use LinkORB\Contracts\UserbaseRole\RoleManagerInterface;
 use LinkORB\Contracts\UserbaseRole\RoleProviderInterface;
 use RuntimeException;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
 use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use UserBase\Client\Event\UserLoadedEvent;
 use UserBase\Client\Model\User;
 
@@ -38,7 +38,7 @@ class UserProvider implements UserProviderInterface, RoleManagerInterface
             $user = $this->client->getUserByUsername($username);
             if ($this->dispatcher) {
                 $event = new UserLoadedEvent($user);
-                $this->dispatcher->dispatch('userbase.user_loaded', $event);
+                $this->dispatcher->dispatch($event, 'userbase.user_loaded');
             }
         } catch (RuntimeException $e) {
             throw new UsernameNotFoundException(

--- a/src/UserProvider.php
+++ b/src/UserProvider.php
@@ -2,19 +2,16 @@
 
 namespace UserBase\Client;
 
-use RuntimeException;
-
 use LinkORB\Contracts\UserbaseRole\RoleManagerInterface;
 use LinkORB\Contracts\UserbaseRole\RoleProviderInterface;
+use RuntimeException;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
 use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-
-use UserBase\Client\Model\User;
 use UserBase\Client\Event\UserLoadedEvent;
-
+use UserBase\Client\Model\User;
 
 class UserProvider implements UserProviderInterface, RoleManagerInterface
 {
@@ -77,6 +74,6 @@ class UserProvider implements UserProviderInterface, RoleManagerInterface
 
     public function supportsClass($class)
     {
-        return $class === User::class;
+        return User::class === $class;
     }
 }


### PR DESCRIPTION
## Proposed changes

[Allow the client library to be used in Symfony 5 projects](https://github.com/linkorb/userbase-client-php/commit/9e6f9b6a0415f243f64386d9d5eb811bcee08803).

## Breaking Change

The `User` class no longer implements Symfony's
`AdvancedUserInterface` which was removed in Symfony 5.  Instead of using
the methods of the removed interface, integrators should implement User
and Account checks in `UserChecker`s.

  A temporary replacement for the removed interface is
  `UserBase\Client\Model\LegacyAdvancedUserInterface`, but use this only as a
  last resort and as a temporary fix.