### PR TITLE
Fixed:  event load class issue

### DIFF
--- a/src/Event/UserLoadedEvent.php
+++ b/src/Event/UserLoadedEvent.php
@@ -2,7 +2,7 @@
 
 namespace UserBase\Client\Event;
 
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 use UserBase\Client\Model\User;
 
 class UserLoadedEvent extends Event


### PR DESCRIPTION
Attempted to load class "Event" from namespace "Symfony\Component\EventDispatcher".
Did you forget a "use" statement for "Symfony\Contracts\EventDispatcher\Event"?

## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If this relates to a card, please include a link to the card here.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/linkorb/.github/blob/master/CONTRIBUTING.md) doc
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added/updated necessary documentation in the README.md or doc/ directories (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
