### PR TITLE
fix: make explicit the dependency on EventDispatcher contract

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "linkorb/userbase-role-contracts": "^2.0",
         "psr/cache": "~1.0",
         "symfony/cache": "~3.0 || ^4.0 || ^5.0",
+        "symfony/event-dispatcher-contracts": "^2.0",
         "symfony/security-core": "~2.6 || ~3.0 || ^4.0 || ^5.0"
     },
     "require-dev": {

--- a/src/Event/UserLoadedEvent.php
+++ b/src/Event/UserLoadedEvent.php
@@ -2,7 +2,7 @@
 
 namespace UserBase\Client\Event;
 
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 use UserBase\Client\Model\User;
 
 class UserLoadedEvent extends Event


### PR DESCRIPTION
This contains and supersedes @kaushikindianic's fix in #25.

Crucially it also makes the dependency on EventDispatcher explicit by requiring the contracts in composer.json.